### PR TITLE
Add Debian-based Magento 2 container stack

### DIFF
--- a/opt/magento-docker/README.md
+++ b/opt/magento-docker/README.md
@@ -1,0 +1,382 @@
+# Magento 2 Debian 12.2 Container Stack
+
+This repository provides a fully containerized Magento 2 platform where every image is built from `debian:12.2-slim`. Services include Nginx (backend), PHP-FPM 8.3, MySQL 8.0, OpenSearch 2.x, Redis 7, Varnish 7, and an Nginx TLS proxy. phpMyAdmin is delivered through the backend Nginx on a dedicated port and proxied via TLS at `pma.mgt.com`.
+
+---
+
+## Project Tree
+
+```
+/opt/magento-docker
+├── certs/
+│   └── .gitkeep
+├── docker-compose.yml
+├── mysql/
+│   ├── Dockerfile
+│   └── docker-entrypoint.sh
+├── nginx-backend/
+│   ├── Dockerfile
+│   └── sites.conf
+├── nginx-ssl/
+│   ├── Dockerfile
+│   └── ssl.conf
+├── opensearch/
+│   ├── Dockerfile
+│   ├── docker-entrypoint.sh
+│   └── opensearch.yml
+├── php-fpm/
+│   ├── Dockerfile
+│   ├── docker-entrypoint.sh
+│   └── php.ini
+├── redis/
+│   ├── Dockerfile
+│   └── redis.conf
+├── varnish/
+│   ├── Dockerfile
+│   └── default.vcl
+└── README.md
+```
+
+---
+
+## Preflight Checklist (Run Before Deployment)
+
+- [ ] **Hardware** – ≥4 vCPU, 12 GB RAM, 60 GB free disk. Enable ≥4 GB swap for Composer stability.
+- [ ] **Host OS** – Debian 12 patched (`sudo apt update && sudo apt upgrade -y`).
+- [ ] **Ports Free** – 80, 443, 8080, 8081, 3306, 6379, 6081, 9200, 9600 unused.
+- [ ] **Firewall** – Allow inbound 80/443 and ensure Docker bridge traffic permitted.
+- [ ] **Hosts file (workstation)** – Add `192.168.1.14 test.mgt.com pma.mgt.com` (or `127.0.0.1` when testing locally).
+- [ ] **Kernel sysctl** – `sudo sysctl -w vm.max_map_count=262144` and persist via `/etc/sysctl.d/99-opensearch.conf`.
+- [ ] **Swap** – Optional but recommended: `sudo fallocate -l 4G /swapfile && sudo chmod 600 /swapfile && sudo mkswap /swapfile && sudo swapon /swapfile`.
+
+---
+
+## Step-by-Step Implementation Guide
+
+### 1. Install Docker Engine + Compose Plugin (Debian Host)
+
+```bash
+sudo apt update
+sudo apt install -y ca-certificates curl gnupg lsb-release
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/debian/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo $VERSION_CODENAME) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+```
+
+Log out/in to activate group membership.
+
+### 2. Obtain the Project
+
+```bash
+sudo mkdir -p /opt
+sudo chown $USER:$USER /opt
+cd /opt
+git clone <this-repo-url> magento-docker
+cd magento-docker/opt/magento-docker
+```
+
+### 3. Prepare Environment Variables (`.env`)
+
+```bash
+cat <<'ENV' > .env
+MYSQL_ROOT_PASSWORD=ChangeMeRoot!234
+MYSQL_DATABASE=magento
+MYSQL_USER=magento
+MYSQL_PASSWORD=ChangeMeApp!234
+ENV
+```
+
+Adjust passwords before production use.
+
+### 4. Generate Self-Signed Certificate (SAN: test.mgt.com, pma.mgt.com)
+
+```bash
+cd /opt/magento-docker/certs
+openssl req -x509 -nodes -days 825 \
+  -newkey rsa:4096 \
+  -keyout test.mgt.com.key \
+  -out test.mgt.com.crt \
+  -subj "/C=US/ST=Denial/L=Springfield/O=Magento Dev/OU=DevOps/CN=test.mgt.com" \
+  -addext "subjectAltName=DNS:test.mgt.com,DNS:pma.mgt.com"
+chmod 600 test.mgt.com.key
+```
+
+### 5. Build and Launch Containers
+
+```bash
+cd /opt/magento-docker
+docker compose --env-file .env build
+sudo sysctl -w vm.max_map_count=262144
+sudo tee /etc/sysctl.d/99-opensearch.conf <<<"vm.max_map_count=262144"
+docker compose --env-file .env up -d
+docker compose ps
+```
+
+Tail critical logs while services initialize:
+
+```bash
+docker compose logs -f --tail=100 mysql opensearch
+```
+
+### 6. Fetch Magento via Composer
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+composer config -g http-basic.repo.magento.com <PUBLIC_KEY> <PRIVATE_KEY>
+cd /var/www/html
+composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.4.6-p4 .
+exit
+exit
+```
+
+If Composer is killed (OOM), ensure swap is enabled then re-run – command is idempotent. For offline mirrors, point Composer to a local artifact repository.
+
+### 7. Run `bin/magento setup:install`
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+cd /var/www/html
+bin/magento setup:install \
+  --base-url=https://test.mgt.com/ \
+  --backend-frontname=admin \
+  --db-host=mysql \
+  --db-name=${MYSQL_DATABASE} \
+  --db-user=${MYSQL_USER} \
+  --db-password=${MYSQL_PASSWORD} \
+  --admin-firstname=Store \
+  --admin-lastname=Admin \
+  --admin-email=admin@example.com \
+  --admin-user=AdminUser99 \
+  --admin-password='ChangeAdmin!234' \
+  --language=en_US \
+  --currency=USD \
+  --timezone=UTC \
+  --use-rewrites=1 \
+  --search-engine=opensearch \
+  --opensearch-host=opensearch \
+  --opensearch-port=9200 \
+  --opensearch-index-prefix=magento \
+  --opensearch-enable-auth=0
+exit
+exit
+```
+
+Re-run only after dropping the database (`bin/magento setup:uninstall`).
+
+### 8. Configure Redis (cache + session)
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+cd /var/www/html
+bin/magento setup:config:set --cache-backend=redis --cache-backend-redis-server=redis --cache-backend-redis-db=0
+bin/magento setup:config:set --page-cache=redis --page-cache-redis-server=redis --page-cache-redis-db=1
+bin/magento setup:config:set --session-save=redis --session-save-redis-host=redis --session-save-redis-port=6379 --session-save-redis-db=2
+exit
+exit
+```
+
+### 9. Force HTTPS Base URLs
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+cd /var/www/html
+bin/magento setup:store-config:set --base-url="https://test.mgt.com/"
+bin/magento setup:store-config:set --base-url-secure="https://test.mgt.com/"
+exit
+exit
+```
+
+### 10. Enable Varnish Full-Page Cache
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+cd /var/www/html
+bin/magento setup:config:set --http-cache-hosts=varnish:6081
+bin/magento cache:enable full_page
+bin/magento varnish:vcl:generate \
+  --export-version=6 \
+  --output-file=/tmp/varnish.vcl \
+  --backend-host=nginx-backend \
+  --backend-port=8080
+exit
+exit
+```
+
+Copy the generated VCL and restart Varnish (safe to repeat):
+
+```bash
+cat /tmp/varnish.vcl | docker exec -i magento-varnish tee /etc/varnish/default.vcl >/dev/null
+docker compose restart varnish
+```
+
+### 11. Compile, Deploy, Warm, Index, Install Cron
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+cd /var/www/html
+bin/magento maintenance:enable
+bin/magento setup:upgrade
+bin/magento setup:di:compile
+bin/magento setup:static-content:deploy -f
+bin/magento maintenance:disable
+bin/magento cache:flush
+bin/magento cache:clean
+bin/magento cache:warmup
+bin/magento indexer:reindex
+bin/magento cron:install
+exit
+exit
+```
+
+Verify cron schedule inside the container if required: `docker compose exec php-fpm crontab -l`.
+
+### 12. Install phpMyAdmin (served on backend port 8081)
+
+```bash
+docker compose exec php-fpm bash
+su - test-ssh
+cd /var/www/html
+curl -fsSL https://files.phpmyadmin.net/phpMyAdmin/5.2.1/phpMyAdmin-5.2.1-all-languages.tar.gz | tar -xz
+rm -rf phpmyadmin
+mv phpMyAdmin-5.2.1-all-languages phpmyadmin
+chmod -R 775 phpmyadmin
+chown -R test-ssh:clp phpmyadmin
+exit
+exit
+```
+
+### 13. Update Hosts File & Access URLs
+
+```
+192.168.1.14 test.mgt.com pma.mgt.com
+```
+
+- Storefront/Admin: https://test.mgt.com, https://test.mgt.com/admin
+- phpMyAdmin: https://pma.mgt.com
+
+---
+
+## Post-Deployment Verification Commands
+
+```bash
+cd /opt/magento-docker
+
+# Container state
+docker compose ps
+
+# TLS + Varnish headers
+curl -kI https://test.mgt.com --resolve test.mgt.com:443:192.168.1.14
+curl -kI https://test.mgt.com --resolve test.mgt.com:443:192.168.1.14 | grep -E 'Via|X-Varnish'
+
+# Magento health
+docker compose exec php-fpm bin/magento cron:run --group=default
+docker compose exec php-fpm bin/magento app:config:dump scopes themes system
+
+# OpenSearch
+docker compose exec opensearch curl -s localhost:9200/_cluster/health
+
+# MySQL
+MYSQL_PWD=${MYSQL_ROOT_PASSWORD} docker compose exec mysql mysqladmin ping -h localhost -p${MYSQL_ROOT_PASSWORD}
+
+# Log spot checks
+docker compose logs --tail=50 varnish nginx-ssl nginx-backend php-fpm
+```
+
+Expect `Via` and `X-Varnish` headers to confirm Varnish is serving responses.
+
+---
+
+## Export & Backup Procedures
+
+### Export Custom Images
+
+```bash
+cd /opt/magento-docker
+docker save magento-mysql:latest -o mysql-image.tar
+docker save magento-php-fpm:latest -o php-fpm-image.tar
+docker save magento-nginx-backend:latest -o nginx-backend-image.tar
+docker save magento-nginx-ssl:latest -o nginx-ssl-image.tar
+docker save magento-varnish:latest -o varnish-image.tar
+docker save magento-redis:latest -o redis-image.tar
+docker save magento-opensearch:latest -o opensearch-image.tar
+```
+
+### Backup Volumes (idempotent)
+
+```bash
+mkdir -p backups
+for vol in mysql-data opensearch-data redis-data magento-app; do
+  docker run --rm -v ${vol}:/volume -v $(pwd)/backups:/backup debian:12.2-slim \
+    tar czf /backup/${vol}-$(date +%F).tar.gz -C /volume .
+done
+```
+
+### Restore Example
+
+```bash
+for archive in backups/*.tar.gz; do
+  vol=$(basename "$archive" | cut -d'-' -f1-2 | sed 's/-[0-9].*//')
+  docker volume create $vol
+  docker run --rm -v ${vol}:/volume -v $(pwd)/backups:/backup debian:12.2-slim \
+    sh -c "cd /volume && tar xzf /backup/$(basename $archive)"
+done
+```
+
+---
+
+## Roll-Forward / Roll-Back Procedures
+
+- **Roll-forward:**
+  ```bash
+  cd /opt/magento-docker
+  docker compose build --no-cache
+  docker compose up -d --force-recreate
+  ```
+- **Roll-back:**
+  ```bash
+  cd /opt/magento-docker
+  docker compose down
+  # Restore previously saved volume tarballs & image tar files (see backup section)
+  docker load -i <image-tar>
+  docker compose up -d
+  ```
+
+Maintain dated backups to align images and volumes for consistent rollback points.
+
+---
+
+## Troubleshooting Guide
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| 502 Bad Gateway from TLS proxy | PHP-FPM still starting or crashed | `docker compose logs php-fpm`; rerun Magento setup, then `docker compose restart php-fpm`. |
+| OpenSearch refuses to start | `vm.max_map_count` too low | `sudo sysctl -w vm.max_map_count=262144` and restart `magento-opensearch`. |
+| Mixed-content warnings in browser | Base URLs not HTTPS | Re-run Step 9 to enforce secure URLs and flush cache. |
+| Composer killed/OOM | Insufficient RAM | Add swap (see Preflight) and rerun Composer. |
+| Redirect loop after enabling Varnish | Magento cache misconfiguration | Flush caches (`bin/magento cache:flush`), verify `app/etc/env.php` for correct `http_cache_hosts`. |
+
+---
+
+## Final Readiness Checklist (“All Green”)
+
+- [ ] Docker services healthy (`docker compose ps` shows `Up` with passing healthchecks).
+- [ ] TLS certificate/key present in `certs/` with restricted permissions.
+- [ ] Magento storefront/admin reachable via HTTPS and presents `Via` + `X-Varnish` headers.
+- [ ] phpMyAdmin accessible at `https://pma.mgt.com` through TLS proxy.
+- [ ] Redis and OpenSearch enabled in `app/etc/env.php`.
+- [ ] Backups of images and volumes completed.
+- [ ] Roll-forward/roll-back playbooks validated.
+- [ ] Monitoring commands scripted/available (curl, bin/magento checks, log tails).
+
+Tick all boxes before declaring the environment deployable.

--- a/opt/magento-docker/docker-compose.yml
+++ b/opt/magento-docker/docker-compose.yml
@@ -1,0 +1,137 @@
+version: "3.9"
+
+services:
+  mysql:
+    build:
+      context: ./mysql
+    image: magento-mysql:latest
+    container_name: magento-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:?set MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE:-magento}
+      MYSQL_USER: ${MYSQL_USER:-magento}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:?set MYSQL_PASSWORD}
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    networks:
+      - magento
+
+  opensearch:
+    build:
+      context: ./opensearch
+    image: magento-opensearch:latest
+    container_name: magento-opensearch
+    environment:
+      discovery.type: single-node
+      plugins.security.disabled: "true"
+      OPENSEARCH_JAVA_OPTS: "-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - opensearch-data:/usr/share/opensearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fsSL http://localhost:9200/_cluster/health || exit 1"]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    networks:
+      - magento
+    ports:
+      - "9200:9200"
+    sysctls:
+      vm.max_map_count: "262144"
+
+  redis:
+    build:
+      context: ./redis
+    image: magento-redis:latest
+    container_name: magento-redis
+    command: ["redis-server", "/etc/redis/redis.conf"]
+    volumes:
+      - redis-data:/var/lib/redis
+    networks:
+      - magento
+
+  php-fpm:
+    build:
+      context: ./php-fpm
+    image: magento-php-fpm:latest
+    container_name: magento-php-fpm
+    environment:
+      PHP_MEMORY_LIMIT: "2048M"
+    volumes:
+      - magento-app:/var/www/html
+    networks:
+      - magento
+
+  nginx-backend:
+    build:
+      context: ./nginx-backend
+    image: magento-nginx-backend:latest
+    container_name: magento-nginx-backend
+    depends_on:
+      - php-fpm
+    volumes:
+      - magento-app:/var/www/html
+      - ./nginx-backend/sites.conf:/etc/nginx/conf.d/sites.conf:ro
+    ports:
+      - "8080:8080"
+      - "8081:8081"
+    networks:
+      - magento
+
+  varnish:
+    build:
+      context: ./varnish
+    image: magento-varnish:latest
+    container_name: magento-varnish
+    depends_on:
+      nginx-backend:
+        condition: service_started
+    environment:
+      VARNISH_BACKEND_HOST: nginx-backend
+      VARNISH_BACKEND_PORT: "8080"
+    volumes:
+      - ./varnish/default.vcl:/etc/varnish/default.vcl
+    ports:
+      - "6081:6081"
+    networks:
+      - magento
+
+  nginx-ssl:
+    build:
+      context: ./nginx-ssl
+    image: magento-nginx-ssl:latest
+    container_name: magento-nginx-ssl
+    depends_on:
+      varnish:
+        condition: service_started
+      nginx-backend:
+        condition: service_started
+    volumes:
+      - ./nginx-ssl/ssl.conf:/etc/nginx/conf.d/ssl.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    ports:
+      - "80:80"
+      - "443:443"
+    networks:
+      - magento
+
+volumes:
+  mysql-data:
+  opensearch-data:
+  redis-data:
+  magento-app:
+
+networks:
+  magento:
+    driver: bridge

--- a/opt/magento-docker/mysql/Dockerfile
+++ b/opt/magento-docker/mysql/Dockerfile
@@ -1,0 +1,24 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gnupg wget lsb-release ca-certificates \
+    && echo "deb http://repo.mysql.com/apt/debian/ bookworm mysql-8.0" > /etc/apt/sources.list.d/mysql.list \
+    && wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2022 | gpg --dearmor > /etc/apt/trusted.gpg.d/mysql.gpg \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends mysql-server pwgen gosu \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/lib/mysql /var/run/mysqld \
+    && chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+VOLUME ["/var/lib/mysql"]
+
+EXPOSE 3306
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["mysqld"]

--- a/opt/magento-docker/mysql/docker-entrypoint.sh
+++ b/opt/magento-docker/mysql/docker-entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "${1}" == "mysqld" ]]; then
+  if [ ! -d /var/lib/mysql/mysql ]; then
+    echo "Initializing MySQL data directory"
+    mysqld --initialize-insecure --user=mysql --datadir=/var/lib/mysql
+  fi
+
+  chown -R mysql:mysql /var/lib/mysql /var/run/mysqld
+
+  if [ -n "${MYSQL_ROOT_PASSWORD:-}" ]; then
+    tfile=$(mktemp)
+    cat <<SQL > "$tfile"
+ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}';
+CREATE USER IF NOT EXISTS '${MYSQL_USER:-magento}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD:-magento}';
+CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE:-magento}\` CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+GRANT ALL PRIVILEGES ON \`${MYSQL_DATABASE:-magento}\`.* TO '${MYSQL_USER:-magento}'@'%';
+FLUSH PRIVILEGES;
+SQL
+    set -- "$@" --init-file="$tfile"
+  fi
+
+  exec gosu mysql "$@"
+fi
+
+exec "$@"

--- a/opt/magento-docker/nginx-backend/Dockerfile
+++ b/opt/magento-docker/nginx-backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nginx curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rm /etc/nginx/sites-enabled/default
+
+COPY sites.conf /etc/nginx/conf.d/sites.conf
+
+EXPOSE 8080 8081
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/opt/magento-docker/nginx-backend/sites.conf
+++ b/opt/magento-docker/nginx-backend/sites.conf
@@ -1,0 +1,64 @@
+upstream php-fpm {
+    server php-fpm:9000;
+}
+
+server {
+    listen 8080;
+    server_name test.mgt.com;
+    root /var/www/html;
+    index index.php index.html;
+
+    add_header X-Content-Type-Options nosniff;
+    add_header X-Frame-Options SAMEORIGIN;
+    add_header X-XSS-Protection "1; mode=block";
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location /pub/static/ {
+        alias /var/www/html/pub/static/;
+        expires max;
+        add_header Cache-Control "public";
+    }
+
+    location /pub/media/ {
+        alias /var/www/html/pub/media/;
+        expires max;
+        add_header Cache-Control "public";
+    }
+
+    location ~ \.(php|phtml)$ {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_read_timeout 600;
+        fastcgi_pass php-fpm;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|webp)$ {
+        try_files $uri =404;
+        expires max;
+        add_header Cache-Control "public";
+    }
+
+    location ~* \.(htaccess|git|env|xml)$ {
+        deny all;
+    }
+}
+
+server {
+    listen 8081;
+    server_name pma.mgt.com;
+    root /var/www/html/phpmyadmin;
+    index index.php;
+
+    location / {
+        try_files $uri $uri/ /index.php?$args;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass php-fpm;
+    }
+}

--- a/opt/magento-docker/nginx-ssl/Dockerfile
+++ b/opt/magento-docker/nginx-ssl/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nginx openssl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rm /etc/nginx/sites-enabled/default
+
+COPY ssl.conf /etc/nginx/conf.d/ssl.conf
+
+EXPOSE 80 443
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/opt/magento-docker/nginx-ssl/ssl.conf
+++ b/opt/magento-docker/nginx-ssl/ssl.conf
@@ -1,0 +1,43 @@
+server {
+    listen 80;
+    server_name test.mgt.com pma.mgt.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name test.mgt.com;
+
+    ssl_certificate /etc/nginx/certs/test.mgt.com.crt;
+    ssl_certificate_key /etc/nginx/certs/test.mgt.com.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass http://varnish:6081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    server_name pma.mgt.com;
+
+    ssl_certificate /etc/nginx/certs/test.mgt.com.crt;
+    ssl_certificate_key /etc/nginx/certs/test.mgt.com.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    location / {
+        proxy_pass http://nginx-backend:8081;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+    }
+}

--- a/opt/magento-docker/opensearch/Dockerfile
+++ b/opt/magento-docker/opensearch/Dockerfile
@@ -1,0 +1,30 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    OPENSEARCH_VERSION=2.11.1 \
+    OPENSEARCH_HOME=/usr/share/opensearch
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg openjdk-17-jdk-headless unzip tar bash \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --home ${OPENSEARCH_HOME} --shell /usr/sbin/nologin opensearch \
+    && mkdir -p ${OPENSEARCH_HOME}
+
+RUN curl -fsSL https://artifacts.opensearch.org/releases/bundle/opensearch/${OPENSEARCH_VERSION}/opensearch-${OPENSEARCH_VERSION}-linux-x64.tar.gz | tar -xz -C /tmp \
+    && mv /tmp/opensearch-${OPENSEARCH_VERSION} ${OPENSEARCH_HOME} \
+    && chown -R opensearch:opensearch ${OPENSEARCH_HOME}
+
+COPY opensearch.yml ${OPENSEARCH_HOME}/config/opensearch.yml
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chown opensearch:opensearch ${OPENSEARCH_HOME}/config/opensearch.yml \
+    && chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 9200 9600
+
+USER opensearch
+
+WORKDIR ${OPENSEARCH_HOME}
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["opensearch"]

--- a/opt/magento-docker/opensearch/docker-entrypoint.sh
+++ b/opt/magento-docker/opensearch/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "$1" = "opensearch" ]; then
+  export OPENSEARCH_PATH_CONF="${OPENSEARCH_HOME}/config"
+  exec ${OPENSEARCH_HOME}/bin/opensearch
+fi
+
+exec "$@"

--- a/opt/magento-docker/opensearch/opensearch.yml
+++ b/opt/magento-docker/opensearch/opensearch.yml
@@ -1,0 +1,7 @@
+cluster.name: magento-opensearch
+node.name: magento-node
+network.host: 0.0.0.0
+discovery.type: single-node
+http.port: 9200
+plugins.security.disabled: true
+indices.query.bool.max_clause_count: 4096

--- a/opt/magento-docker/php-fpm/Dockerfile
+++ b/opt/magento-docker/php-fpm/Dockerfile
@@ -1,0 +1,39 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl gnupg2 unzip git libicu72 libxml2 libzip4 libjpeg62-turbo libpng16-16 libfreetype6 libxslt1.1 libonig5 libwebp7 libmagickwand-6.q16-6 \
+    && curl -fsSL https://packages.sury.org/php/apt.gpg | gpg --dearmor -o /etc/apt/trusted.gpg.d/sury.gpg \
+    && echo "deb https://packages.sury.org/php/ bookworm main" > /etc/apt/sources.list.d/php.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends php8.3 php8.3-cli php8.3-fpm php8.3-bcmath php8.3-common php8.3-curl php8.3-gd php8.3-intl php8.3-mbstring php8.3-mysql php8.3-soap php8.3-xml php8.3-xsl php8.3-zip php8.3-opcache php8.3-sockets php8.3-simplexml php8.3-imagick php8.3-pcntl php8.3-fileinfo php8.3-readline php8.3-redis \
+    && apt-get install -y --no-install-recommends supervisor cron openssh-client default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd -g 1000 clp \
+    && useradd -u 1000 -g clp -m -s /bin/bash test-ssh
+
+RUN mkdir -p /var/www/html /var/log/php8.3-fpm \
+    && chown -R test-ssh:clp /var/www/html /var/log/php8.3-fpm
+
+RUN sed -i 's|^user = www-data|user = test-ssh|' /etc/php/8.3/fpm/pool.d/www.conf \
+    && sed -i 's|^group = www-data|group = clp|' /etc/php/8.3/fpm/pool.d/www.conf \
+    && sed -i 's|^listen = .*|listen = 0.0.0.0:9000|' /etc/php/8.3/fpm/pool.d/www.conf \
+    && sed -i 's|^;listen.allowed_clients = 127.0.0.1|listen.allowed_clients = 0.0.0.0|' /etc/php/8.3/fpm/pool.d/www.conf
+
+RUN sed -i 's|;daemonize = yes|daemonize = no|' /etc/php/8.3/fpm/php-fpm.conf
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+COPY php.ini /etc/php/8.3/fpm/conf.d/99-magento.ini
+COPY php.ini /etc/php/8.3/cli/conf.d/99-magento.ini
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /var/www/html
+
+ENV PATH="/var/www/html/bin:$PATH"
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["php-fpm8.3", "-F"]

--- a/opt/magento-docker/php-fpm/docker-entrypoint.sh
+++ b/opt/magento-docker/php-fpm/docker-entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+PHP_MEMORY_LIMIT=${PHP_MEMORY_LIMIT:-2048M}
+
+for ini in /etc/php/8.3/fpm/conf.d/99-magento.ini /etc/php/8.3/cli/conf.d/99-magento.ini; do
+  sed -i "s/^memory_limit = .*/memory_limit = ${PHP_MEMORY_LIMIT}/" "$ini"
+done
+
+mkdir -p /var/www/html/var /var/www/html/generated /var/www/html/pub/static /var/www/html/pub/media
+chown -R test-ssh:clp /var/www/html
+
+service cron start
+
+if [[ "${1}" == php-fpm8.3* ]]; then
+  exec "$@"
+fi
+
+exec "$@"

--- a/opt/magento-docker/php-fpm/php.ini
+++ b/opt/magento-docker/php-fpm/php.ini
@@ -1,0 +1,15 @@
+[PHP]
+date.timezone = UTC
+memory_limit = 2048M
+max_execution_time = 1800
+zlib.output_compression = On
+realpath_cache_size = 10M
+realpath_cache_ttl = 7200
+
+[opcache]
+opcache.enable = 1
+opcache.enable_cli = 1
+opcache.memory_consumption = 512
+opcache.max_accelerated_files = 65407
+opcache.validate_timestamps = 1
+opcache.revalidate_freq = 0

--- a/opt/magento-docker/redis/Dockerfile
+++ b/opt/magento-docker/redis/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends redis-server \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /var/lib/redis \
+    && chown redis:redis /var/lib/redis
+
+COPY redis.conf /etc/redis/redis.conf
+
+VOLUME ["/var/lib/redis"]
+
+EXPOSE 6379
+
+USER redis
+
+CMD ["redis-server", "/etc/redis/redis.conf"]

--- a/opt/magento-docker/redis/redis.conf
+++ b/opt/magento-docker/redis/redis.conf
@@ -1,0 +1,5 @@
+bind 0.0.0.0
+protected-mode no
+port 6379
+dir /var/lib/redis
+maxmemory-policy allkeys-lru

--- a/opt/magento-docker/varnish/Dockerfile
+++ b/opt/magento-docker/varnish/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:12.2-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends varnish \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY default.vcl /etc/varnish/default.vcl
+
+EXPOSE 6081
+
+CMD ["varnishd", "-F", "-f", "/etc/varnish/default.vcl", "-s", "malloc,256m"]

--- a/opt/magento-docker/varnish/default.vcl
+++ b/opt/magento-docker/varnish/default.vcl
@@ -1,0 +1,10 @@
+vcl 4.1;
+
+backend default {
+    .host = "nginx-backend";
+    .port = "8080";
+}
+
+sub vcl_recv {
+    return (pass);
+}


### PR DESCRIPTION
## Summary
- add a docker-compose based Magento 2 stack built entirely from debian:12.2-slim images
- implement custom Dockerfiles and entrypoints for MySQL, OpenSearch, PHP-FPM, Redis, Varnish, and Nginx services
- document full installation, verification, backup, and troubleshooting workflows for the stack

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dababe35148333b1d0360a181488d4